### PR TITLE
Travis CI: Lint with flake8 to find undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
   - python --version
   - pip --version
   - mkdir ~/.cloudmesh
-  - sudo pip install pyyaml --upgrade --force
+  # - sudo pip install pyyaml --upgrade --force  # TODO: This line is breaking the Travis build
   - sudo pip install lockfile
   - curl -L http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/pycrypto-2.6.1.tar.gz | tar xz
   - cd pycrypto-2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,13 @@ install:
   - pip install -U -r requirements-doc.txt
   - pip install -U -r requirements-test.txt
   - pip install -U .
+  - pip install flake8
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - pwd


### PR DESCRIPTION
_undefined names_ have the potential to raise _NameError_ at runtime.  These could be missing imports, errors in refactoring, etc.